### PR TITLE
Add new allowed domain for images in Advanced Data Analysis

### DIFF
--- a/app/src/main/java/org/woheller69/gptassist/MainActivity.java
+++ b/app/src/main/java/org/woheller69/gptassist/MainActivity.java
@@ -205,6 +205,7 @@ public class MainActivity extends Activity {
         //Allowed Domains
         allowedDomains.add("cdn.auth0.com");
         allowedDomains.add("openai.com");
+        allowedDomains.add("fileserviceuploadsperm.blob.core.windows.net");
 
     }
 }


### PR DESCRIPTION
Added "fileserviceuploadsperm.blob.core.windows.net" to Allowed Domain for Images in Advanced Data Analysis